### PR TITLE
Add queries for vendor.

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -21,8 +21,13 @@ from .product.schema import ProductMutations, ProductQueries
 from .shipping.schema import ShippingMutations, ShippingQueries
 from .shop.schema import ShopMutations, ShopQueries
 from .translations.schema import TranslationQueries
+from .vendor.schema import (
+    VendorMutations,
+    VendorQueries,
+    VendorWarehouseMutation,
+    VendorWarehouseQueries,
+)
 from .warehouse.schema import StockQueries, WarehouseMutations, WarehouseQueries
-from .vendor.schema import VendorMutations, VendorWarehouseMutation
 from .webhook.schema import WebhookMutations, WebhookQueries
 
 
@@ -46,6 +51,8 @@ class Query(
     ShopQueries,
     StockQueries,
     TranslationQueries,
+    VendorQueries,
+    VendorWarehouseQueries,
     WarehouseQueries,
     WebhookQueries,
 ):
@@ -73,7 +80,7 @@ class Mutation(
     ShippingMutations,
     ShopMutations,
     WarehouseMutations,
-    VendorMutations, # registering for api
+    VendorMutations,  # registering for api
     VendorWarehouseMutation,
     WebhookMutations,
 ):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4767,7 +4767,7 @@ type Query {
   warehouse(id: ID!): Warehouse
   warehouses(filter: WarehouseFilterInput, sortBy: WarehouseSortingInput, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection
   vendorWarehouse(id: ID!): VendorWarehouse
-  vendorWarehouses(filter: VendorWarehouseFilterInput, before: String, after: String, first: Int, last: Int): VendorCountableConnection
+  vendorWarehouses(filter: VendorWarehouseFilterInput, before: String, after: String, first: Int, last: Int): VendorWarehouseCountableConnection
   vendor(id: ID!): Vendor
   vendors(filter: VendorFilterInput, sortBy: VendorSortingInput, before: String, after: String, first: Int, last: Int): VendorCountableConnection
   translations(kind: TranslatableKinds!, before: String, after: String, first: Int, last: Int): TranslatableItemConnection
@@ -5825,7 +5825,7 @@ enum VendorErrorCode {
 
 input VendorFilterInput {
   search: String
-  id: [ID]
+  ids: [ID]
 }
 
 enum VendorSortField {
@@ -5847,6 +5847,17 @@ type VendorWarehouse implements Node {
   id: ID!
   vendorId: Vendor!
   warehouse: Warehouse
+}
+
+type VendorWarehouseCountableConnection {
+  pageInfo: PageInfo!
+  edges: [VendorWarehouseCountableEdge!]!
+  totalCount: Int
+}
+
+type VendorWarehouseCountableEdge {
+  node: VendorWarehouse!
+  cursor: String!
 }
 
 type VendorWarehouseCreate {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4766,6 +4766,10 @@ type Query {
   webhookSamplePayload(eventType: WebhookSampleEventTypeEnum!): JSONString
   warehouse(id: ID!): Warehouse
   warehouses(filter: WarehouseFilterInput, sortBy: WarehouseSortingInput, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection
+  vendorWarehouse(id: ID!): VendorWarehouse
+  vendorWarehouses(filter: VendorWarehouseFilterInput, before: String, after: String, first: Int, last: Int): VendorCountableConnection
+  vendor(id: ID!): Vendor
+  vendors(filter: VendorFilterInput, sortBy: VendorSortingInput, before: String, after: String, first: Int, last: Int): VendorCountableConnection
   translations(kind: TranslatableKinds!, before: String, after: String, first: Int, last: Int): TranslatableItemConnection
   translation(id: ID!, kind: TranslatableKinds!): TranslatableItem
   stock(id: ID!): Stock
@@ -5775,6 +5779,17 @@ type Vendor implements Node {
   slug: String!
 }
 
+type VendorCountableConnection {
+  pageInfo: PageInfo!
+  edges: [VendorCountableEdge!]!
+  totalCount: Int
+}
+
+type VendorCountableEdge {
+  node: Vendor!
+  cursor: String!
+}
+
 type VendorCreate {
   vendorErrors: [VendorError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [VendorError!]!
@@ -5808,6 +5823,20 @@ enum VendorErrorCode {
   UNIQUE
 }
 
+input VendorFilterInput {
+  search: String
+  id: [ID]
+}
+
+enum VendorSortField {
+  NAME
+}
+
+input VendorSortingInput {
+  direction: OrderDirection!
+  field: VendorSortField!
+}
+
 type VendorUpdate {
   vendorErrors: [VendorError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [VendorError!]!
@@ -5830,6 +5859,10 @@ type VendorWarehouseDelete {
   vendorErrors: [VendorError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [VendorError!]!
   vendorWarehouse: VendorWarehouse
+}
+
+input VendorWarehouseFilterInput {
+  search: String
 }
 
 input VendorWarehouseInput {

--- a/saleor/graphql/vendor/filters.py
+++ b/saleor/graphql/vendor/filters.py
@@ -1,0 +1,37 @@
+import django_filters
+from graphene_django.filter import GlobalIDMultipleChoiceFilter
+
+from ...vendor.models import Vendor
+from ..core.types import FilterInputObjectType
+from ..utils.filters import filter_by_query_param
+
+
+def prefetch_qs_for_filter(qs):
+    return qs.prefetch_related("user")
+
+
+def filter_search_vendor(qs, _, value):
+    search_fields = {
+        "shop_name",
+        "user__email",
+        "user__first_name",
+    }
+    if value:
+        qs = prefetch_qs_for_filter(qs)
+        qs = filter_by_query_param(qs, value, search_fields)
+
+    return qs
+
+
+class VendorFilter(django_filters.FilterSet):
+    search = django_filters.CharFilter(method=filter_search_vendor)
+    id = GlobalIDMultipleChoiceFilter(field_name="id")
+
+    class Meta:
+        model = Vendor
+        fields = []
+
+
+class VendorFilterInput(FilterInputObjectType):
+    class Meta:
+        filterset_class = VendorFilter

--- a/saleor/graphql/vendor/filters.py
+++ b/saleor/graphql/vendor/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
-from ...vendor.models import Vendor
+from ...vendor.models import Vendor, VendorWarehouse
 from ..core.types import FilterInputObjectType
 from ..utils.filters import filter_by_query_param
 
@@ -23,6 +23,20 @@ def filter_search_vendor(qs, _, value):
     return qs
 
 
+def filter_search_vendor_warehouse(qs, _, value):
+    search_fields = {
+        "vendor_id__shop_name",
+        "vendor_id__user__email",
+        "vendor_id__user__first_name",
+        "warehouse__name",
+    }
+    if value:
+        qs = qs.select_related("vendor", "warehouse")
+        qs = filter_by_query_param(qs, value, search_fields)
+
+    return qs
+
+
 class VendorFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_search_vendor)
     id = GlobalIDMultipleChoiceFilter(field_name="id")
@@ -35,3 +49,16 @@ class VendorFilter(django_filters.FilterSet):
 class VendorFilterInput(FilterInputObjectType):
     class Meta:
         filterset_class = VendorFilter
+
+
+class VendorWarehouseFilter(django_filters.FilterSet):
+    search = django_filters.CharFilter(method=filter_search_vendor_warehouse)
+
+    class Meta:
+        model = VendorWarehouse
+        fields = []
+
+
+class VendorWarehouseFilterInput(FilterInputObjectType):
+    class Meta:
+        filterset_class = VendorWarehouseFilter

--- a/saleor/graphql/vendor/filters.py
+++ b/saleor/graphql/vendor/filters.py
@@ -39,7 +39,7 @@ def filter_search_vendor_warehouse(qs, _, value):
 
 class VendorFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_search_vendor)
-    id = GlobalIDMultipleChoiceFilter(field_name="id")
+    ids = GlobalIDMultipleChoiceFilter(field_name="id")
 
     class Meta:
         model = Vendor

--- a/saleor/graphql/vendor/resolvers.py
+++ b/saleor/graphql/vendor/resolvers.py
@@ -1,0 +1,9 @@
+from ...vendor import models
+
+
+def resolve_vendor(id):
+    return models.Vendor.objects.filter(id=id).first()
+
+
+def resolve_vendors():
+    return models.Warehouse.objects.all()

--- a/saleor/graphql/vendor/resolvers.py
+++ b/saleor/graphql/vendor/resolvers.py
@@ -6,4 +6,4 @@ def resolve_vendor(id):
 
 
 def resolve_vendors():
-    return models.Warehouse.objects.all()
+    return models.Vendor.objects.all()

--- a/saleor/graphql/vendor/resolvers.py
+++ b/saleor/graphql/vendor/resolvers.py
@@ -7,3 +7,11 @@ def resolve_vendor(id):
 
 def resolve_vendors():
     return models.Vendor.objects.all()
+
+
+def resolve_vendor_warehouse(id):
+    return models.VendorWarehouse.objects.filter(id=id).first()
+
+
+def resolve_vendor_warehouses():
+    return models.VendorWarehouse.objects.all()

--- a/saleor/graphql/vendor/schema.py
+++ b/saleor/graphql/vendor/schema.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ..core.utils import from_global_id_or_error
 from .filters import VendorFilterInput
 from .mutations import (
     VendorCreate,
@@ -9,6 +10,7 @@ from .mutations import (
     VendorWarehouseDelete,
     VendorWarehouseUpdate,
 )
+from .resolvers import resolve_vendor, resolve_vendors
 from .types import Vendor
 
 
@@ -36,3 +38,11 @@ class VendorQueries(graphene.ObjectType):
     vendors = graphene.Field(
         Vendor, description="List of vendors.", filter=VendorFilterInput()
     )
+
+    def resolve_vendor(self, info, **data):
+        vendor_pk = data.get("id")
+        _, id = from_global_id_or_error(vendor_pk, Vendor)
+        return resolve_vendor(id)
+
+    def resolve_vendors(self, info, **_kwargs):
+        return resolve_vendors()

--- a/saleor/graphql/vendor/schema.py
+++ b/saleor/graphql/vendor/schema.py
@@ -1,7 +1,8 @@
 import graphene
 
+from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
-from .filters import VendorFilterInput
+from .filters import VendorFilterInput, VendorWarehouseFilterInput
 from .mutations import (
     VendorCreate,
     VendorDelete,
@@ -10,8 +11,14 @@ from .mutations import (
     VendorWarehouseDelete,
     VendorWarehouseUpdate,
 )
-from .resolvers import resolve_vendor, resolve_vendors
-from .types import Vendor
+from .resolvers import (
+    resolve_vendor,
+    resolve_vendor_warehouse,
+    resolve_vendor_warehouses,
+    resolve_vendors,
+)
+from .sorters import VendorSortingInput
+from .types import Vendor, VendorWarehouse
 
 
 # registering the mutaion for schema here which takes automatically when
@@ -35,8 +42,11 @@ class VendorQueries(graphene.ObjectType):
         id=graphene.Argument(graphene.ID, description="ID of a vendor", required=True),
     )
 
-    vendors = graphene.Field(
-        Vendor, description="List of vendors.", filter=VendorFilterInput()
+    vendors = FilterInputConnectionField(
+        Vendor,
+        description="List of vendors.",
+        filter=VendorFilterInput(),
+        sort_by=VendorSortingInput(),
     )
 
     def resolve_vendor(self, info, **data):
@@ -46,3 +56,24 @@ class VendorQueries(graphene.ObjectType):
 
     def resolve_vendors(self, info, **_kwargs):
         return resolve_vendors()
+
+
+class VendorWarehouseQueries(graphene.ObjectType):
+    vendor_warehouse = graphene.Field(
+        VendorWarehouse,
+        description="Look up vendor's warehouse by ID.",
+        id=graphene.ID(required=True, description="ID of a vendor"),
+    )
+    vendor_warehouses = FilterInputConnectionField(
+        Vendor,
+        description="List of vendor warehouses.",
+        filter=VendorWarehouseFilterInput(),
+    )
+
+    def resolve_vendor_warehouse(self, info, **data):
+        vendor_warehouse_id = data.get("id")
+        _, id = from_global_id_or_error(vendor_warehouse_id, VendorWarehouse)
+        return resolve_vendor_warehouse(id)
+
+    def resolve_vendor_warehouses(self, info, **_kwargs):
+        return resolve_vendor_warehouses()

--- a/saleor/graphql/vendor/schema.py
+++ b/saleor/graphql/vendor/schema.py
@@ -1,21 +1,38 @@
 import graphene
+
+from .filters import VendorFilterInput
 from .mutations import (
     VendorCreate,
     VendorDelete,
     VendorUpdate,
     VendorWarehouseCreate,
     VendorWarehouseDelete,
-    VendorWarehouseUpdate
+    VendorWarehouseUpdate,
 )
+from .types import Vendor
 
-# registering the mutaion for schema here which takes automatically when 
+
+# registering the mutaion for schema here which takes automatically when
 # run command npm run build-schema
 class VendorMutations(graphene.ObjectType):
     create_vendor = VendorCreate.Field()
     delete_vendor = VendorDelete.Field()
     update_vendor = VendorUpdate.Field()
 
+
 class VendorWarehouseMutation(graphene.ObjectType):
     create_vendorWarehouse = VendorWarehouseCreate.Field()
     update_vendorWarehouse = VendorWarehouseUpdate.Field()
     delete_vendorWarehouse = VendorWarehouseDelete.Field()
+
+
+class VendorQueries(graphene.ObjectType):
+    vendor = graphene.Field(
+        Vendor,
+        description="Look up a vendor by ID.",
+        id=graphene.Argument(graphene.ID, description="ID of a vendor", required=True),
+    )
+
+    vendors = graphene.Field(
+        Vendor, description="List of vendors.", filter=VendorFilterInput()
+    )

--- a/saleor/graphql/vendor/schema.py
+++ b/saleor/graphql/vendor/schema.py
@@ -65,7 +65,7 @@ class VendorWarehouseQueries(graphene.ObjectType):
         id=graphene.ID(required=True, description="ID of a vendor"),
     )
     vendor_warehouses = FilterInputConnectionField(
-        Vendor,
+        VendorWarehouse,
         description="List of vendor warehouses.",
         filter=VendorWarehouseFilterInput(),
     )

--- a/saleor/graphql/vendor/sorters.py
+++ b/saleor/graphql/vendor/sorters.py
@@ -4,12 +4,12 @@ from ..core.types import SortInputObjectType
 
 
 class VendorSortField(graphene.Enum):
-    NAME = ["name", "slug"]
+    NAME = ["shop_name", "slug"]
 
     @property
     def description(self):
-        if self.name in VendorSortField.__enum__.member_names_:
-            sort_name = self.name.lower().replace("_", " ")
+        if self.shop_name in VendorSortField.__enum__.member_names_:
+            sort_name = self.shop_name.lower().replace("_", " ")
             return f"Sort vendors by {sort_name}."
         raise ValueError("Unsupported enum value: %s" % self.value)
 

--- a/saleor/graphql/vendor/sorters.py
+++ b/saleor/graphql/vendor/sorters.py
@@ -1,0 +1,20 @@
+import graphene
+
+from ..core.types import SortInputObjectType
+
+
+class VendorSortField(graphene.Enum):
+    NAME = ["name", "slug"]
+
+    @property
+    def description(self):
+        if self.name in VendorSortField.__enum__.member_names_:
+            sort_name = self.name.lower().replace("_", " ")
+            return f"Sort vendors by {sort_name}."
+        raise ValueError("Unsupported enum value: %s" % self.value)
+
+
+class VendorSortingInput(SortInputObjectType):
+    class Meta:
+        sort_enum = VendorSortField
+        type_name = "vendors"


### PR DESCRIPTION
I want to merge this change to enable access of vendor app models through graphql api. Vendor and Vendor warehouse can be queried with this change to access the vendor and his warehouse object. Address issue #4 
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
